### PR TITLE
Fix login redirects to respect locale

### DIFF
--- a/src/app/[locale]/(auth)/forgot-password/page.tsx
+++ b/src/app/[locale]/(auth)/forgot-password/page.tsx
@@ -5,6 +5,7 @@ import { useForm } from 'react-hook-form'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 import Link from 'next/link'
+import { useParams } from 'next/navigation'
 import { requestPasswordReset } from '@/server/actions/auth'
 
 import { Button } from '@/components/ui/button'
@@ -26,6 +27,7 @@ interface ForgotPasswordFormData {
 
 export default function ForgotPasswordPage() {
   const t = useTranslations()
+  const { locale } = useParams()
   const [error, setError] = useState<string>('')
   const [isEmailSent, setIsEmailSent] = useState(false)
   
@@ -38,7 +40,7 @@ export default function ForgotPasswordPage() {
   const onSubmit = async (data: ForgotPasswordFormData) => {
     try {
       setError('')
-      const result = await requestPasswordReset(data)
+      const result = await requestPasswordReset(data, locale as string)
       
       if (result?.error) {
         setError(result.error)

--- a/src/app/[locale]/(auth)/login/components/LoginForm.tsx
+++ b/src/app/[locale]/(auth)/login/components/LoginForm.tsx
@@ -4,6 +4,7 @@ import { useForm } from 'react-hook-form'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { useState } from 'react'
+import { useParams } from 'next/navigation'
 import { login } from '@/server/actions/auth'
 import { Button } from '@/components/ui/button'
 import {
@@ -20,6 +21,7 @@ interface LoginFormData {
 
 export default function LoginForm() {
     const t = useTranslations()
+    const { locale } = useParams()
     const [error, setError] = useState<string>('')
     const [isSubmitting, setIsSubmitting] = useState(false)
     
@@ -33,8 +35,8 @@ export default function LoginForm() {
       try {
         setIsSubmitting(true)
         setError('')
-        
-        const result = await login(data)
+
+        const result = await login(data, locale as string)
         
         if (result?.error) {
           setError(result.error)

--- a/src/app/[locale]/(auth)/login/hooks/useLogin.ts
+++ b/src/app/[locale]/(auth)/login/hooks/useLogin.ts
@@ -10,7 +10,7 @@ export interface LoginFormData {
   password: string
 }
 
-export function useLogin() {
+export function useLogin(locale: string) {
   const t = useTranslations()
   const [error, setError] = useState<string>('')
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -20,7 +20,7 @@ export function useLogin() {
       setIsSubmitting(true)
       setError('')
       
-      const result = await login(data)
+      const result = await login(data, locale)
       
       if (result?.error) {
         setError(result.error)

--- a/src/app/[locale]/(auth)/register/components/RegisterForm.tsx
+++ b/src/app/[locale]/(auth)/register/components/RegisterForm.tsx
@@ -7,8 +7,10 @@ import { CardContent, CardFooter } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { useRegister } from '../hooks/useRegister'
+import { useParams } from 'next/navigation'
 
 export default function RegisterForm() {
+  const { locale } = useParams()
   const {
     registerField,
     handleSubmit,
@@ -16,7 +18,7 @@ export default function RegisterForm() {
     isSubmitting,
     error,
     onSubmit
-  } = useRegister()
+  } = useRegister(locale as string)
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/app/[locale]/(auth)/register/hooks/useRegister.ts
+++ b/src/app/[locale]/(auth)/register/hooks/useRegister.ts
@@ -11,7 +11,7 @@ export interface RegisterFormData {
   password: string
 }
 
-export function useRegister() {
+export function useRegister(locale: string) {
   const t = useTranslations()
   const [error, setError] = useState<string>('')
   
@@ -25,7 +25,7 @@ export function useRegister() {
     try {
       setError('')
       
-      const result = await register(data)
+      const result = await register(data, locale)
       
       if (result?.error) {
         setError(result.error)

--- a/src/app/[locale]/(auth)/reset-password/page.tsx
+++ b/src/app/[locale]/(auth)/reset-password/page.tsx
@@ -4,6 +4,7 @@
 import { useForm } from 'react-hook-form'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
+import { useParams } from 'next/navigation'
 import { resetPassword } from '@/server/actions/auth'
 
 import { Button } from '@/components/ui/button'
@@ -26,6 +27,7 @@ interface ResetPasswordFormData {
 
 export default function ResetPasswordPage() {
   const t = useTranslations()
+  const { locale } = useParams()
   const [error, setError] = useState<string>('')
   
   const {
@@ -46,7 +48,7 @@ export default function ResetPasswordPage() {
         return
       }
 
-      const result = await resetPassword({ password: data.password })
+      const result = await resetPassword({ password: data.password }, locale as string)
       
       if (result?.error) {
         setError(result.error)

--- a/src/server/actions/auth.ts
+++ b/src/server/actions/auth.ts
@@ -23,7 +23,7 @@ interface PasswordResetData {
   password: string
 }
 
-export async function register(data: RegisterData) {
+export async function register(data: RegisterData, locale: string) {
   const supabase = await createClient()
 
   const { data: authData, error } = await supabase.auth.signUp({
@@ -53,10 +53,10 @@ export async function register(data: RegisterData) {
     return { error: 'Este email já está associado a uma conta. Tente recuperar sua senha.' }
   }
 
-  redirect('/pt-BR/verify-email')
+  redirect(`/${locale}/verify-email`)
 }
 
-export async function login(data: LoginData) {
+export async function login(data: LoginData, locale: string) {
   const supabase = await createClient()
 
   const { error } = await supabase.auth.signInWithPassword({
@@ -76,14 +76,17 @@ export async function login(data: LoginData) {
     }
   }
 
-  redirect('/workouts')
+  redirect(`/${locale}/workouts`)
 }
 
-export async function requestPasswordReset(data: PasswordResetRequestData) {
+export async function requestPasswordReset(
+  data: PasswordResetRequestData,
+  locale: string
+) {
   const supabase = await createClient()
 
   const { error } = await supabase.auth.resetPasswordForEmail(data.email, {
-    redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/pt-BR/reset-password`,
+    redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/${locale}/reset-password`,
   })
 
   if (error) {
@@ -97,7 +100,7 @@ export async function requestPasswordReset(data: PasswordResetRequestData) {
 }
 
 
-export async function resetPassword(data: PasswordResetData) {
+export async function resetPassword(data: PasswordResetData, locale: string) {
   const supabase = await createClient()
 
   const { error } = await supabase.auth.updateUser({
@@ -116,7 +119,7 @@ export async function resetPassword(data: PasswordResetData) {
     }
   }
 
-  redirect('/workouts')
+  redirect(`/${locale}/workouts`)
 }
 
 export async function logout(locale: string) {


### PR DESCRIPTION
## Summary
- fix locale-aware redirects in auth actions
- pass locale to auth server actions from client forms

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485212df3c8320b40c8dd3601bf049